### PR TITLE
Added support for querying multiple result sets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ const insertedCount = await sql.execute(
 		name: { val: "josh", type: sql.nvarchar( 20 ) }
 	} );
 
+// querySets, returns an array of object arrays
+const usersWithPageInfo = await sql.querySets( query, params );
+
 // query, returns an array of objects
 const users = await sql.query( query, params );
 
@@ -51,14 +54,24 @@ const userId = await sql.queryValue( query, params );
 If you need to pass an array of parameters into your query, there are two ways to do so.
 
 ### Simple Values
-Assign `val` to an array of simple values(strings, numbers, etc.) and `type` to be the sql type of each item. Skwell will create a table parameter with a single column named `value`
+Assign `val` to an array of simple values(strings, numbers, etc.) and `type` to be the sql type of each item. Skwell will expand the parameter list and create one parameter per value.
 ``` js
-await sql.query( "select value from @ids", {
+await sql.query( "select * from my_table where id in @ids", {
 	ids: {
 		val: [ 1, 2, 3 ],
 		type: sql.int
 	} );
-// [ { value: 1 }, { value: 2 }, { value: 3 } ]
+// query gets expanded to "select * from my_table where id in (@ids0, @ids1, @ids2)
+```
+
+If you pass in an empty array, skwell will instead provide SQL that generates an empty set.
+``` js
+await sql.query( "select * from my_table where id in @ids", {
+	ids: {
+		val: [],
+		type: sql.int
+	} );
+// query gets expanded to "select * from my_table where id in (SELECT 1 WHERE 1=0)
 ```
 
 ### Complex Values

--- a/spec/integration/basic.spec.js
+++ b/spec/integration/basic.spec.js
@@ -83,6 +83,26 @@ describe( "Basic - Integration", () => {
 				] );
 		} );
 
+		it( "should work with multiple sets", () => {
+			const query = `
+				SELECT *
+				FROM QueryTests
+				ORDER BY id DESC;
+
+				SELECT sum(id)
+				FROM QueryTests`;
+
+			return sql.query( query )
+				.should.eventually.deep.equal( [
+					[
+						{ id: 3, test: "C" },
+						{ id: 2, test: "B" },
+						{ id: 1, test: "A" }
+					],
+					[ { "": 6 } ]
+				] );
+		} );
+
 		it( "should work with params", () => {
 			const query = `
 				SELECT *

--- a/spec/integration/basic.spec.js
+++ b/spec/integration/basic.spec.js
@@ -99,7 +99,7 @@ describe( "Basic - Integration", () => {
 						{ id: 2, test: "B" },
 						{ id: 1, test: "A" }
 					],
-					[ { "": 6 } ]
+					[ { 0: 6 } ]
 				] );
 		} );
 

--- a/spec/integration/basic.spec.js
+++ b/spec/integration/basic.spec.js
@@ -68,6 +68,64 @@ describe( "Basic - Integration", () => {
 		} );
 	} );
 
+	describe( "querySets", () => {
+		it( "should work without params", () => {
+			const query = `
+				SELECT *
+				FROM QueryTests
+				ORDER BY id DESC;
+
+				SELECT sum(id)
+				FROM QueryTests;`;
+
+			return sql.querySets( query )
+				.should.eventually.deep.equal( [
+					[
+						{ id: 3, test: "C" },
+						{ id: 2, test: "B" },
+						{ id: 1, test: "A" }
+					],
+					[ { 0: 6 } ]
+				] );
+		} );
+
+		it( "should work with params", () => {
+			const query = `
+				SELECT *
+				FROM QueryTests
+				WHERE id > @id
+				ORDER BY id DESC;
+
+				SELECT sum(id)
+				FROM QueryTests
+				WHERE id > @id;`;
+
+			return sql.querySets( query, {
+				id: { val: 1, type: sql.int }
+			} )
+				.should.eventually.deep.equal( [
+					[
+						{ id: 3, test: "C" },
+						{ id: 2, test: "B" }
+					],
+					[ { 0: 5 } ]
+				] );
+		} );
+
+		it( "should reject on a sql error", () => {
+			const query = `
+				SELECT *
+				FROM QueryTests
+				ORDER BY id DESC;
+
+				SELECT sum(id)
+				FROM QueryTests;`;
+
+			return sql.query( query )
+				.should.be.rejectedWith( "Query returns more than one set of data. Use querySets method to return multiple sets of data." );
+		} );
+	} );
+
 	describe( "query", () => {
 		it( "should work without params", () => {
 			const query = `
@@ -80,26 +138,6 @@ describe( "Basic - Integration", () => {
 					{ id: 3, test: "C" },
 					{ id: 2, test: "B" },
 					{ id: 1, test: "A" }
-				] );
-		} );
-
-		it( "should work with multiple sets", () => {
-			const query = `
-				SELECT *
-				FROM QueryTests
-				ORDER BY id DESC;
-
-				SELECT sum(id)
-				FROM QueryTests`;
-
-			return sql.query( query )
-				.should.eventually.deep.equal( [
-					[
-						{ id: 3, test: "C" },
-						{ id: 2, test: "B" },
-						{ id: 1, test: "A" }
-					],
-					[ { 0: 6 } ]
 				] );
 		} );
 
@@ -172,7 +210,24 @@ describe( "Basic - Integration", () => {
 				.should.eventually.deep.equal( [ ] );
 		} );
 
+		it( "should return an empty array when sql returns nothing", () => {
+			const query = "";
+
+			return sql.query( query )
+				.should.eventually.deep.equal( [] );
+		} );
+
 		it( "should reject on a sql error", () => {
+			const query = `
+				SELECT *
+				FROM lol
+				WHERE BadSql=1;`;
+
+			return sql.query( query )
+				.should.be.rejectedWith( "Invalid object name 'lol'." );
+		} );
+
+		it( "should reject when query returns more than one set of data", () => {
 			const query = `
 				SELECT *
 				FROM lol

--- a/src/api.js
+++ b/src/api.js
@@ -9,8 +9,8 @@ function transformRow( row ) {
 	// TODO: maybe we need to make some decisions based on the sql type?
 	// TODO: opportunity to camelCase here?
 	// TODO: maybe we need to give the user the power to take over here?
-	return row.reduce( ( acc, col ) => {
-		acc[ col.metadata.colName ] = col.value;
+	return row.reduce( ( acc, col, i ) => {
+		acc[ col.metadata.colName || i ] = col.value;
 		return acc;
 	}, {} );
 }
@@ -58,26 +58,26 @@ class Api {
 		const _sql = await sql;
 		return this.withConnection( conn => {
 			const sets = [];
-			let data;
+			let rows;
 			return new Promise( ( resolve, reject ) => {
 				const request = new Request( _sql, err => {
 					if ( err ) {
 						return reject( err );
 					}
 					if ( sets.length ) {
-						sets.push( data );
+						sets.push( rows );
 						return resolve( sets );
 					}
-					return resolve( data );
+					return resolve( rows );
 				} );
 				addRequestParams( request, params );
 				request.on( "columnMetadata", () => {
-					if ( data ) {
-						sets.push( data );
+					if ( rows ) {
+						sets.push( rows );
 					}
-					data = [];
+					rows = [];
 				} );
-				request.on( "row", obj => data.push( transformRow( obj ) ) );
+				request.on( "row", obj => rows.push( transformRow( obj ) ) );
 				conn.execSql( request );
 			} );
 		} );


### PR DESCRIPTION
![](https://m.popkey.co/b3dd4d/MV30E_f-maxage-0.gif)
`query` just returns an array of arrays when querying multiple sets. Is this a terrible idea?